### PR TITLE
Assert task creation has valid keyword

### DIFF
--- a/src/main/java/cue/command/commands/CreateTaskCommand.java
+++ b/src/main/java/cue/command/commands/CreateTaskCommand.java
@@ -3,7 +3,6 @@ package cue.command.commands;
 import cue.command.Command;
 import cue.command.CommandContext;
 import cue.errors.CueException;
-import cue.errors.UnknownCommandException;
 import cue.formatter.StringFormatter;
 import cue.parser.CommandParser;
 import cue.tasks.Deadline;
@@ -22,17 +21,18 @@ public class CreateTaskCommand implements Command {
         case "todo" -> new Todo(input.getBody());
         case "deadline" -> new Deadline(input.getBody(), input.getTag("by"));
         case "event" -> new Event(input.getBody(), input.getTag("from"), input.getTag("to"));
-        default -> throw new UnknownCommandException();
+        default -> null;
         };
 
-        if (newTask != null) {
-            context.tasklist.addTask(newTask);
-            String output = StringFormatter.joinWithNewlines(
-                    "Got it. I've added this task:",
-                    StringFormatter.indent(newTask.toString()),
-                    "Now you have " + context.tasklist.getSize() + " tasks in the list");
+        // new task should always match one of the cases
+        assert newTask != null;
 
-            context.ui.display(output);
-        }
+        context.tasklist.addTask(newTask);
+        String output = StringFormatter.joinWithNewlines(
+                "Got it. I've added this task:",
+                StringFormatter.indent(newTask.toString()),
+                "Now you have " + context.tasklist.getSize() + " tasks in the list");
+
+        context.ui.display(output);
     }
 }


### PR DESCRIPTION
The create task command throws an invalid command exception if the keyword does not match a known keyword. However, this behaviour is not entirely precise.

Using an assertion will help clarify that this command should never be used with keywords other than todo, deadline and event.

Let's:
* remove the exception throw
* assert that newTask should never be null
* remove the unnecessary guard condition